### PR TITLE
Show file details inside sidebar

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -1764,6 +1764,7 @@ content: HIDDEN_CONTENT
         }
         onTabChange={setActiveTab}
         rightSidebarWide={agentsSidebarTab === 'notes' || agentsSidebarTab === 'scenarios'}
+        leftSidebarWide={files.selectedFile !== null}
         researchLoadingIndicator={undefined}
       />
 

--- a/src/components/chat/ChatLayout.tsx
+++ b/src/components/chat/ChatLayout.tsx
@@ -38,6 +38,7 @@ interface ChatLayoutProps {
   onTabChange: (tab: 'chat' | 'files' | 'agents') => void;
   chatPadding?: string;
   rightSidebarWide?: boolean;
+  leftSidebarWide?: boolean;
   researchLoadingIndicator?: ReactNode;
 }
 
@@ -54,15 +55,17 @@ export function ChatLayout({
   onTabChange,
   chatPadding = "",
   rightSidebarWide = false,
+  leftSidebarWide = false,
   researchLoadingIndicator
 }: ChatLayoutProps) {
   const rightSidebarWidth = rightSidebarWide ? "w-96" : "w-64";
+  const leftSidebarWidth = leftSidebarWide ? "w-96" : "w-64";
   
   return (
     <div className="flex flex-col lg:flex-row h-screen bg-white overflow-hidden">
       {/* Left Sidebar - Only visible on desktop */}
       {!isMobile && (
-        <div className="w-64 border-r border-slate-200 bg-white hidden lg:block">
+        <div className={`${leftSidebarWidth} border-r border-slate-200 bg-white hidden lg:block transition-all duration-300`}>
           {leftSidebar}
         </div>
       )}
@@ -92,11 +95,14 @@ export function ChatLayout({
             
             {/* Input component - Fixed at the bottom of chat */}
             {inputComponent && (
-              <div className={cn(
-                "fixed bottom-0 left-0 right-0 lg:left-64 z-10 bg-transparent transition-all duration-300", 
-                isMobile ? "px-2 py-2" : "px-20 py-3",
-                rightSidebarWide ? "lg:right-96" : "lg:right-64" 
-              )}>
+              <div
+                className={cn(
+                  "fixed bottom-0 left-0 right-0 z-10 bg-transparent transition-all duration-300",
+                  isMobile ? "px-2 py-2" : "px-20 py-3",
+                  rightSidebarWide ? "lg:right-96" : "lg:right-64",
+                  leftSidebarWide ? "lg:left-96" : "lg:left-64"
+                )}
+              >
                 {inputComponent}
               </div>
             )}

--- a/src/components/chat/FileDetailModal.tsx
+++ b/src/components/chat/FileDetailModal.tsx
@@ -303,10 +303,10 @@ content: ${content}
   };
   
   return (
-    <div className="fixed inset-0 bg-white z-50 flex flex-col h-screen w-screen">
+    <div className="relative bg-white z-50 flex flex-col h-full w-full overflow-y-auto">
       {/* Notification */}
       {notification && (
-        <div className="fixed top-6 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-80 text-white px-4 py-2 rounded shadow-lg z-[60] text-sm">
+        <div className="absolute top-6 left-1/2 transform -translate-x-1/2 bg-black bg-opacity-80 text-white px-4 py-2 rounded shadow-lg z-[60] text-sm">
           {notification}
         </div>
       )}

--- a/src/components/chat/FileSidebar.tsx
+++ b/src/components/chat/FileSidebar.tsx
@@ -1049,8 +1049,21 @@ export function FileSidebar({
     }
   }, [fileUploads]);
 
+  if (selectedFile) {
+    return (
+      <div className={`${isMobile ? 'w-full' : 'w-full border-r'} bg-white border-light h-full flex flex-col relative`}>
+        <FileDetailModal
+          file={selectedFile}
+          onClose={() => setSelectedFile(null)}
+          onSendMessage={onSendMessage}
+          onFileQuickAction={onFileQuickAction}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div className={`${isMobile ? 'w-full' : 'w-64 border-r'} bg-white border-light h-full flex flex-col`}>
+    <div className={`${isMobile ? 'w-full' : 'w-full border-r'} bg-white border-light h-full flex flex-col`}>
       <div 
         className={`sticky top-0 z-10 flex justify-between items-center h-[60px] px-4 ${isMobile ? 'hidden' : ''} bg-white`}
         style={{ 
@@ -1345,15 +1358,6 @@ export function FileSidebar({
         )}
       </div>
       
-      {/* Render the file detail modal when a file is selected */}
-      {selectedFile && (
-        <FileDetailModal 
-          file={selectedFile} 
-          onClose={() => setSelectedFile(null)} 
-          onSendMessage={onSendMessage}
-          onFileQuickAction={onFileQuickAction}
-        />
-      )}
     </div>
   );
 } 


### PR DESCRIPTION
## Summary
- allow ChatLayout to widen the left sidebar
- open FileSidebar details panel inside the sidebar
- size the modal to fit inside its parent
- trigger leftSidebarWide when a file is selected

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-next')*
- `npm run build`